### PR TITLE
Updating definition of year field

### DIFF
--- a/DATA_GUIDANCE.md
+++ b/DATA_GUIDANCE.md
@@ -63,7 +63,7 @@ The source from which an emission factor was retrieved. This refers to the publi
 
 ### year
 
-Year for which the emission factor has been calculated according to the source. This number can differ from the year of publication.
+Year of publication of the emission factor by the source. Note that this is typically not the year from which the emissions were calculated - care should be taken when applying emission factors that may vary year-on-year.
 
 ### region
 


### PR DESCRIPTION
**Is this a new addition or an update to an existing factor?**

- [ ] New
- [x] Update

**What category or categories does it affect?**

All

**What?**

We are aligning all sources in the database with this definition

**Why?**

Currently there is no consistency in whether the year reflects the year of publication or that of calculation. We have decided to reflect publication as it best reflects the recency of the emission factor; many emission factors may be calculated from very old data but still be relevant (e.g. using fuel creates the same amount of emissions in 2021 as it did in 2011), but having the calculation date makes the database appear incorrectly out of date. 

