### PR TITLE
Pin versions of validation-related dependencies to resolve a GitHub action caching issue

### DIFF
--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -33,6 +33,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.1.13
           virtualenvs-create: true
           virtualenvs-in-project: true
       - name: Load cached venv

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: poetry-${{ runner.os }}-${{ hashFiles('.github/workflows/validate-using-python-oefdb-sdk.yaml') }}
+          key: poetry-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('.github/workflows/validate-using-python-oefdb-sdk.yaml') }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -43,7 +43,6 @@ jobs:
           key: venv-${{ runner.os }}-${{matrix.python}}-${{ hashFiles('python-oefdb-sdk/pyproject.toml') }}
       - name: Install dependencies
         run: poetry install --no-dev
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         working-directory: python-oefdb-sdk
       - name: Validate file
         run: poetry run oefdb_validate -i ../OpenEmissionFactorsDB.csv

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: python-oefdb-sdk/.venv
-          key: venv-${{ runner.os }}-${{matrix.python}}-${{ hashFiles('python-oefdb-sdk/pyproject.toml') }}
+          key: venv-${{ runner.os }}-${{matrix.python}}-${{ hashFiles('.github/workflows/validate-using-python-oefdb-sdk.yaml') }}-${{ hashFiles('python-oefdb-sdk/pyproject.toml') }}
       - name: Install dependencies
         run: poetry install --no-dev
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [ 3.9 ]
+        python: [ 3.9.12 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -43,6 +43,7 @@ jobs:
           key: venv-${{ runner.os }}-${{matrix.python}}-${{ hashFiles('python-oefdb-sdk/pyproject.toml') }}
       - name: Install dependencies
         run: poetry install --no-dev
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         working-directory: python-oefdb-sdk
       - name: Validate file
         run: poetry run oefdb_validate -i ../OpenEmissionFactorsDB.csv


### PR DESCRIPTION
**What?**

Attempts to resolve a GitHub action caching issue.
The changes here ought to make caching work more reliably in the future. It seems that the caching feature broke because of Python releasing new minor versions. With these changes, Python-related versions are pinned down to known working ones, so that it shouldn't break on new Python releases.

Since the cache only gets updated once validation passes and validation currently fails, we need to resolve the validation errors before we can know for sure that the caching issue is resolved.

**Why?**

A poetry/python-related caching issue started cropping up recently, eg in https://github.com/climatiq/Open-Emission-Factors-DB/runs/5848156989?check_suite_focus=true

