### PR TITLE
Add autofixing and UUIDS

### DIFF
--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -63,7 +63,8 @@ jobs:
           poetry run oefdb_validate_schema -i ../OpenEmissionFactorsDB.csv -s ../metadata/schema.toml --fix 2>&1 | tee test.log
           result_code=${PIPESTATUS[0]}
           
-          # There is a limit to how long we can make comments - so if we have too much output we need to truncate it
+          # There is a limit to how much input we can pass into the comment action
+          # So if we have too much output here we need to truncate it
           if [[ $(wc -l < test.log) -ge 100 ]]
           then
               START=$(cat "test.log" | head -n 50)
@@ -76,6 +77,7 @@ jobs:
           
           # Github deals terribly with multiline strings.
           # So we have to replace them with escape chars here and then Github will automatically unescape
+          # Otherwise we can only capture the first line of our string
           # see https://github.community/t/set-output-truncates-multiline-strings/16852/4
           RESULT="${RESULT//'%'/'%25'}"
           RESULT="${RESULT//$'\n'/'%0A'}"
@@ -93,9 +95,9 @@ jobs:
         id: auto-commit-action
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-            commit_message: 'Automatically fixing via SDK'
+            commit_message: 'Automatic fixes by the OEFDB validator'
 
-      - name: 'Write autofix comment'
+      - name: 'Add comment to PR discussion thread'
         if: steps.auto-commit-action.outputs.changes_detected == 'true'
         uses: actions/github-script@v5
         with:
@@ -105,5 +107,5 @@ jobs:
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  body: `# Automatic fix applied \n The SDK has encountered something it could fix automatically. \n It has automatically fixed some lines and pushed a new commit to your branch. \n\n  Please inspect the output below, and pull down the latest commit to ensure that everything looks right. \n \`\`\`\n ${{ steps.schema_validation.outputs.cli_output }} \n\`\`\``
+                  body: `# Automatic fix applied \n The OEFDB validator has encountered something it could fix automatically. \n It has automatically changed some lines and pushed a new commit to your branch. \n\n  Please inspect the output below, and run `git pull` to update your local branch if you want to keep working. \n \`\`\`\n ${{ steps.schema_validation.outputs.cli_output }} \n\`\`\``
                 });

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -49,12 +49,17 @@ jobs:
       - name: Validate OEFDB
         run: poetry run oefdb_validate -i ../OpenEmissionFactorsDB.csv
         working-directory: python-oefdb-sdk
+
+      # This CI script validates and autofixes any issues in the OEFDB
+      # It's unfortunately a big tangle of bash, as we want to capture the output and have it available later
+      # and Github actions is surprisingly bad at that.
       - name: Validate OEFDB schema
         if: always() # Always attempt schema validation even if another validation fails
         id: schema_validation
         working-directory: python-oefdb-sdk
         run: |
           # See https://stackoverflow.com/a/66713349/8007580 for this solution that allows us to capture output while still failing
+          # the entire CI run if an error occurs
           poetry run oefdb_validate_schema -i ../OpenEmissionFactorsDB.csv -s ../metadata/schema.toml --fix 2>&1 | tee test.log
           result_code=${PIPESTATUS[0]}
           
@@ -63,7 +68,7 @@ jobs:
           then
               START=$(cat "test.log" | head -n 50)
               END=$(cat "test.log" | tail -n 50)
-              nl=$'\n'
+              nl=$'\n' # We have to do this newline trick, otherwise the newlines are not escaped later for some reason
               RESULT="$START $nl ... MIDDLE OF OUTPUT TRUNCATED BECAUSE IT'S TOO LONG ...  $nl $END"
           else
               RESULT=$(cat test.log)
@@ -75,12 +80,14 @@ jobs:
           RESULT="${RESULT//'%'/'%25'}"
           RESULT="${RESULT//$'\n'/'%0A'}"
           RESULT="${RESULT//$'\r'/'%0D'}"
+          
+          # Assign the modified result so it is accessible later
           echo "::set-output name=cli_output::$RESULT"
+          # And then exit with the original exit code of the command
           exit $result_code
 
         # If autofix has changed some files, we commit them here
         # Note that this does not trigger an extra CI run. See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
-
       - name: Commits and pushes changed files
         if: always() # Previous step will fail if it still cannot validate after fixes - in that case we still want to commit the fixes
         id: auto-commit-action

--- a/.github/workflows/validate-using-python-oefdb-sdk.yaml
+++ b/.github/workflows/validate-using-python-oefdb-sdk.yaml
@@ -50,6 +50,53 @@ jobs:
         run: poetry run oefdb_validate -i ../OpenEmissionFactorsDB.csv
         working-directory: python-oefdb-sdk
       - name: Validate OEFDB schema
-        if: always()
-        run: poetry run oefdb_validate_schema -i ../OpenEmissionFactorsDB.csv -s ../metadata/schema.toml
+        if: always() # Always attempt schema validation even if another validation fails
+        id: schema_validation
         working-directory: python-oefdb-sdk
+        run: |
+          # See https://stackoverflow.com/a/66713349/8007580 for this solution that allows us to capture output while still failing
+          poetry run oefdb_validate_schema -i ../OpenEmissionFactorsDB.csv -s ../metadata/schema.toml --fix 2>&1 | tee test.log
+          result_code=${PIPESTATUS[0]}
+          
+          # There is a limit to how long we can make comments - so if we have too much output we need to truncate it
+          if [[ $(wc -l < test.log) -ge 100 ]]
+          then
+              START=$(cat "test.log" | head -n 50)
+              END=$(cat "test.log" | tail -n 50)
+              nl=$'\n'
+              RESULT="$START $nl ... MIDDLE OF OUTPUT TRUNCATED BECAUSE IT'S TOO LONG ...  $nl $END"
+          else
+              RESULT=$(cat test.log)
+          fi
+          
+          # Github deals terribly with multiline strings.
+          # So we have to replace them with escape chars here and then Github will automatically unescape
+          # see https://github.community/t/set-output-truncates-multiline-strings/16852/4
+          RESULT="${RESULT//'%'/'%25'}"
+          RESULT="${RESULT//$'\n'/'%0A'}"
+          RESULT="${RESULT//$'\r'/'%0D'}"
+          echo "::set-output name=cli_output::$RESULT"
+          exit $result_code
+
+        # If autofix has changed some files, we commit them here
+        # Note that this does not trigger an extra CI run. See https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs
+
+      - name: Commits and pushes changed files
+        if: always() # Previous step will fail if it still cannot validate after fixes - in that case we still want to commit the fixes
+        id: auto-commit-action
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+            commit_message: 'Automatically fixing via SDK'
+
+      - name: 'Write autofix comment'
+        if: steps.auto-commit-action.outputs.changes_detected == 'true'
+        uses: actions/github-script@v5
+        with:
+            github-token: ${{secrets.GITHUB_TOKEN}}
+            script: |
+                github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `# Automatic fix applied \n The SDK has encountered something it could fix automatically. \n It has automatically fixed some lines and pushed a new commit to your branch. \n\n  Please inspect the output below, and pull down the latest commit to ensure that everything looks right. \n \`\`\`\n ${{ steps.schema_validation.outputs.cli_output }} \n\`\`\``
+                });

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ package.json
 node_modules
 .DS_Store
 *.bak
+
+# Generated in CI
+python-oefdb-sdk

--- a/metadata/schema.toml
+++ b/metadata/schema.toml
@@ -4,12 +4,13 @@
 # Lines starting with "#"'s are comments
 
 # Explicit documentation for the schema and the validators are available here: https://github.com/climatiq/python-oefdb-sdk#schema-validation
-# See the description of the first column for the structure of the column
+# See the description of the second column for the structure of the column
 
+# First column without comments, for clarity sake
 [[columns]]
 name = "UUID"
-validators = []
-allow_empty = true
+validators = ["is_uuid"]
+allow_empty = false
 
 # The [[columns]] denotes the start of a new column
 # The columns are ordered - it is checked that the columns are in the same order in this file and in the CSV file


### PR DESCRIPTION
This PR adds two things:

## Autofix CI check
- A CI check where it runs the `--fix` that has been added to the new SDK. It will automatically commit any fixes to the branch. This means when you first create a PR without any UUIDs, a new commit will automatically be added with any missing UUIDs, and you will then have to run `git pull` to update your local branch if you want to keep working.
- It will also post a message in the PR with the output of the validator, if any fixes were applied

## Generate UUID
The `metadata.toml` has also been changed to contain the `is_uuid` validator for the UUID column. This validator has a fix which has been applied in this PR - both to test that it works, but also to demonstrate the output (see below)