### PR TITLE
Force LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Always use lf as linefeed (not CRLF on windows)
+# Except for file-types that explicitly require crlf
+# Source:
+# https://code.visualstudio.com/docs/remote/troubleshooting#_resolving-git-line-ending-issues-in-containers-resulting-in-many-modified-files
+
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
For some reason the line endings had been changed to `CRLF` (Windows style) for the OpenEmissionFactorsDb back in #267.

This was fixed in #273 by changing the line-endings back to `LF`(unix-style)

This PR introduces a `.gitattributes` file that forces git to always commit line endings as `LF`, no matter the platform. This should hopefully result in no line-ending shenanigans occurring.